### PR TITLE
Lab1-Exercise 1-Task6-Correct Lifecycle instructions by replacing "Publish" for "Publish to Organization"

### DIFF
--- a/Instructions/Labs/LAB_01/2-exercise-create-declarative-agent.md
+++ b/Instructions/Labs/LAB_01/2-exercise-create-declarative-agent.md
@@ -130,7 +130,7 @@ Next, let’s run the declarative agent in Microsoft 365 Copilot Chat and valida
 
     ![Screenshot of Visual Studio Code. The Teams Toolkit icon is highlighted on the Activity Bar.](../media/LAB_01/teams-toolkit-open.png)
 
-1. In the **Lifecycle** section, select **Publish**. Wait for the actions to complete.
+1. In the **Lifecycle** section, select **Publish to Organization**. Wait for the actions to complete.
 
 1. Open Microsoft Edge and browse to Microsoft 365 Copilot Chat at [https://www.microsoft365.com/chat](https://www.microsoft365.com/chat).
 


### PR DESCRIPTION
This pull request updates the instructions in **MS‑4010-lab1-Exercise1-Task6** to reflect the current UI terminology used in the Lifecycle section.

## What was changed
- Updated the step that previously instructed learners to select **“Publish”**.
- Replaced it with the accurate action: **“Publish to Organization”**.
- Ensures the text matches the button label shown in the current environment.

## Why this change
The Lifecycle UI has been updated, and the **Publish** action now appears as **Publish to Organization**.  
Aligning the lab instructions with the actual UI prevents confusion and ensures learners can follow the process without interruption.

## Conclusion
This adjustment improves clarity and keeps the lab aligned with the latest product experience.  

