### PR TITLE
Fix typo in step by correcting “laning page” to “landing page” in lab 1-exercise 2-task 1

### DIFF
--- a/Instructions/Labs/LAB_01/3-exercise-custom-knowledge.md
+++ b/Instructions/Labs/LAB_01/3-exercise-custom-knowledge.md
@@ -19,7 +19,7 @@ Configure Microsoft Learn as a source of grounding data in the declarative agent
 In Visual Studio Code:
 
 1. In the **appPackage** folder, open **declarativeAgent.json** file.
-1. Add the following code snippet to the file after the **"instructions"** definition, replacing **{URL}** with the direct URL to the Microsoft 365 laning page on Microsoft Learn:
+1. Add the following code snippet to the file after the **"instructions"** definition, replacing **{URL}** with the direct URL to the Microsoft 365 landing page on Microsoft Learn:
 
     ```json
     "capabilities": [


### PR DESCRIPTION
This pull request corrects a typo and improves clarity in the MS‑4010 lab 1-exercise 2-task 1 instructions.

## What was changed
- Corrected the typo **“laning page”** to **“landing page.”**

## Why this change
The original wording contained a typo and was slightly ambiguous regarding where the snippet should be added.  
This update ensures learners can follow the instructions accurately and without confusion.

## Conclusion
This change improves clarity and correctness in the lab, keeping the instructional flow consistent and professional.  
