### PR TITLE
Lab04-Update Teams Toolkit instructions to match current UI

### DIFF
--- a/Instructions/Labs/LAB_04/3-exercise-add-connector-declarative-agent.md
+++ b/Instructions/Labs/LAB_04/3-exercise-add-connector-declarative-agent.md
@@ -21,10 +21,9 @@ To create a new declarative agent, open Visual Studio Code.
 In Visual Studio Code:
 
 1. In the **Activity Bar** (side bar), open the **Teams Toolkit** extension.
-1. In the Teams Toolkit pane, select the **Create a New App** button.
-1. In the **New Project** dialog, choose the **Agent** option.
-1. In the next dialog, choose the **Declarative Agent** option.
-1. Don't add a plugin by selecting the **No plugin** option.
+1. In the Teams Toolkit pane, select the **Create a New Agent/App** button.
+1. In the **New Project** dialog, choose the **Declarative Agent** option.
+1. Don't add a plugin by selecting the **No Action** option.
 1. Select a folder where you want to store the project on your computer.
 1. Name your project `da-it-policies`.
 


### PR DESCRIPTION
## Lab 04 - Exercise 2 -Task 1

## Summary

This pull request updates the Visual Studio Code instructions to align with the current Teams Toolkit UI for creating a Declarative Agent. The previous steps referenced outdated options (such as **Create a New App**, **Agent**, and **Add plugin**) that no longer appear in the current experience, which could cause confusion for learners.

## Changes Proposed

- Updated the Teams Toolkit instructions to use **Create a New Agent/App** instead of **Create a New App**.
- Replaced the deprecated **Agent** option with the current **Declarative Agent** option in the **New Project** dialog.
- Clarified that no plugin should be added by explicitly selecting the **No plugin** option.
- Aligned step wording and sequence with the current Teams Toolkit dialogs shown in Visual Studio Code.

## Conclusion

These changes improve instructional accuracy and ensure the lab reflects the current Teams Toolkit agent creation flow. By removing deprecated options and aligning with the latest UI, the update reduces learner confusion while keeping the lab scope and behavior unchanged.